### PR TITLE
Yaml updates

### DIFF
--- a/lib/ur/json.urs
+++ b/lib/ur/json.urs
@@ -13,6 +13,11 @@ val fromJsonR' : a ::: Type -> json a -> string -> result (a * string)
 val toYaml : a ::: Type -> json a -> a -> string
 val fromYaml : a ::: Type -> json a -> string -> a
 
+(* Versions of fromJson that return a `result` instead of erroring on failure. *)
+val fromYamlR : a ::: Type -> json a -> string -> result a
+val fromYamlR' : a ::: Type -> json a -> string -> result (a * string)
+
+
 val mkJson : a ::: Type -> {ToJson : a -> string,
                             FromJson : string -> result (a * string)} -> json a
 
@@ -40,6 +45,14 @@ val json_record_withOptional : ts ::: {Type} -> ots ::: {Type} -> [ts ~ ots]
                                => folder ts -> $(map json ts) -> $(map (fn _ => string) ts)
                                -> folder ots -> $(map json ots) -> $(map (fn _ => string) ots)
                                -> json $(ts ++ map option ots)
+(* val json_record_withDefaults
+  : ts ::: {Type} -> dts ::: {Type} -> [ts ~ dts]
+  => folder ts -> $(map json ts) -> $(map (fn _ => string) ts)
+  -> folder dts -> $(map json dts) -> $(map (fn t => string * t) dts)
+  -> json $(ts ++ dts)
+
+Write json_record_withOptional simply using this *)
+
 val json_variant : ts ::: {Type} -> folder ts -> $(map json ts) -> $(map (fn _ => string) ts) -> json (variant ts)
 
 (* A version of json_variant that doesn't use labels.  This is generally a bad

--- a/tests/jsonTest.ur
+++ b/tests/jsonTest.ur
@@ -1,44 +1,77 @@
 open Json
 
-type myRow = [A = bool, B = string, C = int]
+
+fun fromJsonTest [t :: Type] (j : json t) (_ : show t) (i : int) (s : string) : xtable = case @@fromJsonR [t] j s of
+    Success t => <xml><tr><td style="border-style: solid; padding: 10px">{[i]}</td><td><pre>{[t]}</pre></td></tr></xml>
+  | Failure x => <xml><tr><td style="border-style: solid; padding: 10px">{[i]}</td><td>{x}</td></tr></xml>
+
+fun toJsonTest [t ::: Type] (j : json t) (i : int) (t : t) : xtable =
+    <xml><tr><td style="border-style: solid; padding: 10px">{[i]}</td><td><pre>{[toJson t]}</pre></td></tr></xml>
+
+fun fromYamlTest [t :: Type] (j : json t) (_ : show t) (i : int) (s : string) : xtable = case @@fromYamlR [t] j s of
+    Success t => <xml><tr><td style="border-style: solid; padding: 10px">{[i]}</td><td><pre>{[t]}</pre></td></tr></xml>
+  | Failure x => <xml><tr><td style="border-style: solid; padding: 10px">{[i]}</td><td>{x}</td></tr></xml>
+
+fun toYamlTest [t ::: Type] (j : json t) (i : int) (t : t) : xtable =
+    <xml><tr><td style="border-style: solid; padding: 10px">{[i]}</td><td><pre>{[toYaml t]}</pre></td></tr></xml>
+
+
+
+type myRow = [A = bool, B = string, C = list (option int), D = int, E = option string]
 
 val _ : show (variant myRow) = mkShow <| fn x => match x {
   A = fn x => "A=" ^ show x,
   B = fn x => "B=\"" ^ show x ^ "\"",
-  C = fn x => "C=" ^ show x}
-val _ : show $myRow = mkShow (fn r => "{A=" ^ show r.A ^ ", B=" ^ show r.B ^ ", C="^ show r.C ^ "}")
-val _ : json $myRow = json_record {A = "A", B = "B", C = "C"}
-
-val (a1,a2,a3,a4) =
-  let val _ : json (variant myRow) = json_variant_anon
-  in
-    ( toJson (make [#B] "foo" : variant myRow)
-    , fromJson "true" : variant myRow
-    , fromJson "35" : variant myRow
-    , fromJson "\"35\"" : variant myRow) end
-
-val (v1,v2,v3,v4) =
-  let val _ : json (variant myRow) = json_variant {A = "A", B = "B", C = "C"}
-  in
-    ( toJson (make [#B] "foo" : variant myRow)
-    , fromJson "{\"A\": true}" : variant myRow
-    , fromJson "{\"C\": 35}" : variant myRow
-    , fromJson "{\"B\": \"35\"}" : variant myRow) end
+  C = fn x => "C=" ^ show x,
+  D = fn x => "D=" ^ show x,
+  E = fn x => "E=" ^ (case x of Some x => show x | None => "null")}
+val _ : show $myRow = mkShow (fn r => "{A=" ^ show r.A ^ ", B=" ^ show r.B ^ ", C="^ show r.C ^ ", D="^ show r.D ^ ", E="^ (case r.E of Some x => show x | None => "null") ^ "}")
+val _ : json $myRow = json_record_withDefaults {A = "A", B = "B", D = "D"} {C = ("C", []), E = ("E", None)}
 
 
+fun main () : transaction page = return <xml><body><table>
+  {fromJsonTest [string] 1 "\"\\\\line \/ 1\\nline 2\""}
+  {fromJsonTest [list int] 2 "[1, 2, 3]"}
+  {toJsonTest 3 ("hi" :: "bye\"" :: "hehe" :: [])}
+  {@@toJsonTest [$myRow] _  4 {A = False, B = "35", C = Some 3 :: None :: [], D = 42, E = None}}
+  {fromJsonTest [$myRow] 5 "{\"A\": false,\"D\": 42,\"B\": \"foo\", \"C\": [3, null]}"}
+  {let val _ : json (variant myRow) = json_variant {A = "A", B = "B", C = "C", D = "D", E = "E"}
+    in <xml>
+    {toJsonTest 6 (make [#B] "foo" : variant myRow)}
+    {fromJsonTest [variant myRow] 7 "{\"A\": true}"}
+    {fromJsonTest [variant myRow] 8 "{\"D\": 35}"}
+    {fromJsonTest [variant myRow] 9 "{\"B\": \"35\"}"}
+    </xml>end}
+  {let val _ : json (variant myRow) = json_variant_anon
+    in <xml>
+    {toJsonTest 10 (make [#B] "foo" : variant myRow)}
+    {fromJsonTest [variant myRow] 11 "true"}
+    {fromJsonTest [variant myRow] 12 "35"}
+    {fromJsonTest [variant myRow] 13 "\"35\""}
+    </xml>end}
+  {fromJsonTest [$myRow] 14 "{\"A\": false,\"D\": 42,\"B\": \"foo\"}"}
+  {@@toJsonTest [$myRow] _ 15 {A = False, B = "35", C = [], D = 42, E = None}}
 
-fun main () : transaction page = return <xml><body>
-  <pre>{[ fromJson "\"\\\\line \/ 1\\nline 2\"" : string ]}</pre><br/>
-  <pre>{[fromJson "[1, 2, 3]" : list int]}</pre><br/>
-  <pre>{[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}</pre><br/>
-  <pre>{[toJson {A = False, B = "35", C = 42}]}</pre><br/>
-  <pre>{[fromJson "{\"A\": false,\"C\": 42,\"B\": \"foo\"}" : $myRow]}</pre><br/>
-  <pre>{[a1]}</pre><br/>
-  <pre>{[a2]}</pre><br/>
-  <pre>{[a3]}</pre><br/>
-  <pre>{[a4]}</pre><br/>
-  <pre>{[v1]}</pre><br/>
-  <pre>{[v2]}</pre><br/>
-  <pre>{[v3]}</pre><br/>
-  <pre>{[v4]}</pre><br/>
+  {fromYamlTest [string] 21 "\"\\\\line \/ 1\\nline 2\""}
+  {fromYamlTest [list int] 22 "-1\n-2\n-3"}
+  {toYamlTest 23 ("hi" :: "bye\"" :: "hehe" :: [])}
+  {@@toYamlTest [$myRow] _  24 {A = False, B = "35", C = Some 3 :: None :: [], D = 42, E = None}}
+  {fromYamlTest [$myRow] 25 "A: false\nD: 42\nC:\n  - 3\n  - null\nB: \"foo\""}
+  {let val _ : json (variant myRow) = json_variant {A = "A", B = "B", C = "C", D = "D", E = "E"}
+    in <xml>
+    {toYamlTest 26 (make [#B] "foo" : variant myRow)}
+    {fromYamlTest [variant myRow] 27 "A: true"}
+    {fromYamlTest [variant myRow] 28 "D: 35"}
+    {fromYamlTest [variant myRow] 29 "B: \"35\""}
+    </xml>end}
+  {let val _ : json (variant myRow) = json_variant_anon
+    in <xml>
+    {toYamlTest 30 (make [#B] "foo" : variant myRow)}
+    {fromYamlTest [variant myRow] 31 "true"}
+    {fromYamlTest [variant myRow] 32 "35"}
+    {fromYamlTest [variant myRow] 33 "\"35\""}
+    </xml>end}
+  {@@toYamlTest [$myRow] _ 34 {A = False, B = "35", C = [], D = 42, E = None}}
+  {fromYamlTest [$myRow] 35 "A: false\nD: 42\nB: \"foo\""}
+  </table>
   </body></xml>

--- a/tests/jsonTest.ur
+++ b/tests/jsonTest.ur
@@ -32,6 +32,7 @@ fun main () : transaction page = return <xml><body>
   <pre>{[fromJson "[1, 2, 3]" : list int]}</pre><br/>
   <pre>{[toJson ("hi" :: "bye\"" :: "hehe" :: [])]}</pre><br/>
   <pre>{[toJson {A = False, B = "35", C = 42}]}</pre><br/>
+  <pre>{[fromJson "{\"A\": false,\"C\": 42,\"B\": \"foo\"}" : $myRow]}</pre><br/>
   <pre>{[a1]}</pre><br/>
   <pre>{[a2]}</pre><br/>
   <pre>{[a3]}</pre><br/>

--- a/tests/jsonTest.urp
+++ b/tests/jsonTest.urp
@@ -3,5 +3,5 @@ rewrite all JsonTest/*
 $/char
 $/string
 $/list
-$/json
+../lib/ur/json
 jsonTest


### PR DESCRIPTION
I ended up going through most of the YAML code and adjusting it with three goals in mind:
- Allow yaml parsing to fail gracefully with a message (i.e., in the `result` type)
- Support yaml variants (or, perhaps, something close to yaml that will work for our purposes)
- Add some docs and make functions simpler and more generic where possible

Some notes:
1. The changes from the first commit observe a compiler bug, where it fails `monoize` with `exception: UnboundNamed`.
2. The second commit supplies a workaround to the problem.
3. The third commit adds more features, but when building nectry with it, compilation seems to stall at reduce.
